### PR TITLE
Allow unauthenticated user registration

### DIFF
--- a/src/main/java/com/example/ecommerce/config/SecurityConfig.java
+++ b/src/main/java/com/example/ecommerce/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**", "/h2-console/**").permitAll() // Public endpoints
+                        .requestMatchers("/auth/**", "/h2-console/**", "/users/register").permitAll() // Public endpoints
                         .anyRequest().authenticated() // Require authentication for other endpoints
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/test/java/com/example/ecommerce/SecurityConfigTest.java
+++ b/src/test/java/com/example/ecommerce/SecurityConfigTest.java
@@ -1,0 +1,34 @@
+package com.example.ecommerce;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void registerEndpointAccessibleWithoutAuth() throws Exception {
+        String json = "{\"email\":\"test@example.com\",\"username\":\"testuser\",\"password\":\"password\"}";
+        mockMvc.perform(post("/users/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void otherEndpointsRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/users/1"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary
- permit `/users/register` to be accessed without authentication
- add integration tests to ensure registration is public and other user endpoints remain protected

## Testing
- `mvn -DskipTests=false test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e7864c3b083318c3d45b70032eb2b