### PR TITLE
Fix duplicate save in product creation

### DIFF
--- a/src/main/java/com/example/ecommerce/controller/ProductController.java
+++ b/src/main/java/com/example/ecommerce/controller/ProductController.java
@@ -67,7 +67,6 @@ public class ProductController {
     @CrossOrigin("*")
     @PostMapping
     public Product createProduct(@RequestBody Product product) {
-        Product savedProduct = productRepository.save(product);
         return productRepository.save(product);
     }
 

--- a/src/test/java/com/example/ecommerce/controller/ProductControllerTest.java
+++ b/src/test/java/com/example/ecommerce/controller/ProductControllerTest.java
@@ -1,0 +1,33 @@
+package com.example.ecommerce.controller;
+
+import com.example.ecommerce.model.Product;
+import com.example.ecommerce.repository.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductControllerTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductController productController;
+
+    @Test
+    void createProductShouldSaveOnceAndReturnSavedEntity() {
+        Product product = new Product();
+        when(productRepository.save(product)).thenReturn(product);
+
+        Product result = productController.createProduct(product);
+
+        assertSame(product, result);
+        verify(productRepository, times(1)).save(product);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid saving products twice in `createProduct`
- add unit test ensuring product is saved once

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e75ec62488331ba82731320962d11